### PR TITLE
print: Support different output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,25 @@ cve-2022-44268-detector is a command line application. You can run it as follows
 
 ```
 $ cve-2022-44268-detector -filename image.png
-***PROFILE CHUNK FOUND! if this was found in a production system, update your dependencies immediately and inspect your systems for evidence of further compromise!***
+***POTENENTIAL INDICATOR OF COMPROMPISE*** - found chunk with keyword 'Raw profile type' | compressed: true | id: 0 | offset: 0x72 | len: 666
 ```
 
-Users may optionally output the contents of the exfiltrated chunk to stdout
-by supplying the `-print` argument. *Please note* that the chunk's value is
+Users may optionally output the contents of each exfiltrated chunk to stdout
+by supplying the `-print` argument. *Please note* that each chunk's value is
 likely binary, zlib-compressed data (i.e., not human-readable). Users are
 strongly advised to redirect this data to a file.
 
+The `-print` argument accepts the following values:
+
+- `raw` - Write the chunk's value as-is to stdout
+- `decompress` - Decompress the chunk's value prior to writing it to stdout
+- `decompress-hexdecode` - Decompress and hex-decode the chunk's value
+  prior to writing it to stdout. ImageMagick appears to first hex-encode
+  and then compress the data using zlib compression
+
 ```
-$ cve-2022-44268-detector -filename image.png -print > /tmp/out
-***PROFILE CHUNK FOUND! if this was found in a production system, update your dependencies immediately and inspect your systems for evidence of further compromise!***
+$ cve-2022-44268-detector -filename image.png -print raw > /tmp/out
+***POTENENTIAL INDICATOR OF COMPROMPISE*** - found chunk with keyword 'Raw profile type' | compressed: true | id: 0 | offset: 0x72 | len: 666
 $ hexdump -C /tmp/out
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cve-2022-44268-detector is a command line application. You can run it as follows
 
 ```
 $ cve-2022-44268-detector -filename image.png
-***POTENENTIAL INDICATOR OF COMPROMPISE*** - found chunk with keyword 'Raw profile type' | compressed: true | id: 0 | offset: 0x72 | len: 666
+***POTENTIAL INDICATOR OF COMPROMISE*** - found chunk with keyword 'Raw profile type' | compressed: true | id: 0 | offset: 0x72 | len: 666
 ```
 
 Users may optionally output the contents of each exfiltrated chunk to stdout
@@ -46,7 +46,7 @@ The `-print` argument accepts the following values:
 
 ```
 $ cve-2022-44268-detector -filename image.png -print raw > /tmp/out
-***POTENENTIAL INDICATOR OF COMPROMPISE*** - found chunk with keyword 'Raw profile type' | compressed: true | id: 0 | offset: 0x72 | len: 666
+***POTENTIAL INDICATOR OF COMPROMISE*** - found chunk with keyword 'Raw profile type' | compressed: true | id: 0 | offset: 0x72 | len: 666
 $ hexdump -C /tmp/out
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ go install github.com/jnschaeffer/cve-2022-44268-detector@latest
 
 ## Warning
 
-*Please be very careful* when working with untrusted data. An attacker can
+**Please be careful** when working with untrusted data. An attacker can
 craft a png chunk that may contain non-zlib data (such as a shell script,
 or code that exploits a bug in your detection workflow). Accidentally
 writing attacker-supplied code to a terminal or to a shell can result in
@@ -35,6 +35,10 @@ Users may optionally output the contents of each exfiltrated chunk to stdout
 by supplying the `-print` argument. *Please note* that each chunk's value is
 likely binary, zlib-compressed data (i.e., not human-readable). Users are
 strongly advised to redirect this data to a file.
+
+**Note: Be very careful when using `-print`.** Untrusted pngs may contain data
+that, if exposed to a terminal or shell, could be interpreted as executable
+code. Please take appropriate precautionary measures when using this feature.
 
 The `-print` argument accepts the following values:
 

--- a/internal/image/png/reader.go
+++ b/internal/image/png/reader.go
@@ -111,6 +111,7 @@ var Debug *log.Logger
 
 // TextChunk represents a tEXt or zTXt chunk in a PNG image.
 type TextChunk struct {
+	Offset     int
 	Keyword    string
 	Compressed bool
 	CompMethod uint8
@@ -130,6 +131,7 @@ type decoder struct {
 	tmp           [3 * 256]byte
 	interlace     int
 	textChunks    []TextChunk
+	cChunkOffset  int
 
 	// useTransparent and transparent are used for grayscale and truecolor
 	// transparency, as opposed to palette transparency.
@@ -955,12 +957,16 @@ func (d *decoder) parsezTXt(length uint32) error {
 }
 
 func (d *decoder) saveTextChunk(chunk TextChunk) error {
+	chunk.Offset = d.cChunkOffset
+
 	d.textChunks = append(d.textChunks, chunk)
 
 	return d.verifyChecksum()
 }
 
 func (d *decoder) parseChunk(configOnly bool) error {
+	d.cChunkOffset = d.r.n
+
 	// Read the length and chunk type.
 	if _, err := io.ReadFull(d.r, d.tmp[:8]); err != nil {
 		return err
@@ -1025,9 +1031,8 @@ func (d *decoder) parseChunk(configOnly bool) error {
 		return d.parseIEND(length)
 	default:
 		if Debug != nil {
-			offset := d.r.n - len(chunkType)
 			Debug.Printf("unknown chunk type: '%s' | length: %d | offset: 0x%x (%d)",
-				chunkType, length, offset, offset)
+				chunkType, length, d.cChunkOffset, d.cChunkOffset)
 		}
 	}
 	if length > 0x7fffffff {

--- a/main.go
+++ b/main.go
@@ -5,11 +5,16 @@
 package main
 
 import (
+	"bytes"
+	"compress/zlib"
+	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/jnschaeffer/cve-2022-44268-detector/internal/image/png"
 )
@@ -32,26 +37,17 @@ const (
 
 var (
 	filename      string
-	printContents bool
+	printContents string
 	debug         bool
 )
 
 func init() {
 	flag.StringVar(&filename, "filename", "", "filename to parse (uses stdin if not set)")
-	flag.BoolVar(&printContents, "print", false, "if set, write the png chunk's value to stdout. Note: This is likely\n"+
-		"binary, zlib-compressed data. Refer to 'zTXt' in RFC 2083")
+	flag.StringVar(&printContents, "print", "",
+		"if set, write each suspicious png chunk's value to stdout.\n"+
+			"May specify: 'raw', 'decompress', 'decompress-hexdecode'")
 	flag.BoolVar(&debug, "debug", false, "enable debug logging if set. The program will emit information about\n"+
 		"unknown png chunk types")
-}
-
-func findProfileChunk(chunks []png.TextChunk) (png.TextChunk, bool) {
-	for _, chunk := range chunks {
-		if chunk.Keyword == profileKeyword {
-			return chunk, true
-		}
-	}
-
-	return png.TextChunk{}, false
 }
 
 func main() {
@@ -61,6 +57,13 @@ func main() {
 
 	if debug {
 		png.Debug = log.New(log.Writer(), "[debug] ", log.Flags()|log.Lmsgprefix)
+	}
+
+	switch printContents {
+	case "", "raw", "decompress", "decompress-hexdecode":
+		// Permitted values.
+	default:
+		log.Fatalf("unknown output mode: '%s'", printContents)
 	}
 
 	var r io.Reader = os.Stdin
@@ -80,20 +83,126 @@ func main() {
 		log.Fatal(err)
 	}
 
-	chunk, found := findProfileChunk(chunks)
-	if !found {
-		fmt.Println("no profile chunk found. this image is likely not malicious")
+	err = findProfileChunks(chunks)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
 
-		// Exit with status code 1 here - technically not finding anything is a failure
-		os.Exit(1)
+func findProfileChunks(chunks []png.TextChunk) error {
+	numFound := 0
+
+	for _, chunk := range chunks {
+		if chunk.Keyword == profileKeyword {
+			log.Printf("***POTENENTIAL INDICATOR OF COMPROMPISE*** - "+
+				"found chunk with keyword '%s' | compressed: %t | id: %d | offset: 0x%x | len: %d",
+				profileKeyword, chunk.Compressed, numFound, chunk.Offset, len(chunk.Value))
+
+			if printContents != "" {
+				err := writeChunkTo(&chunk, os.Stdout)
+				if err != nil {
+					return err
+				}
+			}
+
+			numFound++
+		}
 	}
 
-	log.Println("***PROFILE CHUNK FOUND! if this was found in a production system, update your dependencies immediately and inspect your systems for evidence of further compromise!***")
+	if numFound == 0 {
+		return errors.New("no potential indicators of compromise found")
+	}
 
-	if printContents {
-		_, err := os.Stdout.Write(chunk.Value)
+	return nil
+}
+
+func writeChunkTo(chunk *png.TextChunk, writer io.Writer) error {
+	reader := io.NopCloser(bytes.NewReader(chunk.Value))
+
+	if strings.HasPrefix(printContents, "decompress") && chunk.Compressed {
+		zlibReader, err := zlib.NewReader(reader)
 		if err != nil {
-			log.Fatal(err)
+			return err
+		}
+		defer zlibReader.Close()
+
+		reader = zlibReader
+
+		err = discardWeirdHeaderGarbage(reader)
+		if err != nil {
+			return fmt.Errorf("failed to discard weird header garbage - %w", err)
+		}
+
+		if printContents == "decompress-hexdecode" {
+			// For whatever reason, imagemagick hex-encodes the
+			// chunk's value... and then adds new lines after 72
+			// characters. Thus, we need to filter the newlines.
+			reader = io.NopCloser(hex.NewDecoder(&discardNewLinesReader{
+				r: reader,
+			}))
+		}
+	}
+
+	_, err := io.Copy(writer, reader)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// discardWeirdHeaderGarbage discards the weird header garbage that
+// imagetragic includes in zTXt chunks (this header appears at the
+// beginning of the decompressed data). The header's values appear
+// to be newline delimited. The last value in the header appears to
+// be the length of the hex-encoded data.
+//
+//	 # Note: "267" here is the length of the hex-encoded data.
+//		$ hexdump -C /tmp/out
+//		00000000  0a 0a 20 20 20 20 20 32  36 37 0a 41 41 41 41 41  |..     267.AAAAA|
+func discardWeirdHeaderGarbage(r io.Reader) error {
+	numNewLines := 0
+	b := make([]byte, 1)
+
+	for {
+		_, err := r.Read(b)
+		if err != nil {
+			return err
+		}
+
+		if b[0] == 0x0a {
+			numNewLines++
+
+			if numNewLines == 3 {
+				return nil
+			}
+		}
+	}
+}
+
+// discardNewLinesReader discards any newline (0x0a) characters.
+// It is unbuffered... so, it sucks.
+type discardNewLinesReader struct {
+	r io.Reader
+}
+
+func (o *discardNewLinesReader) Read(p []byte) (int, error) {
+	b := make([]byte, 1)
+	numWrites := 0
+
+	for {
+		_, err := o.r.Read(b)
+		if err != nil {
+			return numWrites, err
+		}
+
+		if b[0] != 0x0a {
+			p[numWrites] = b[0]
+			numWrites++
+		}
+
+		if numWrites == len(p) {
+			return numWrites, nil
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -157,9 +157,9 @@ func writeChunkTo(chunk *png.TextChunk, writer io.Writer) error {
 // to be newline delimited. The last value in the header appears to
 // be the length of the hex-encoded data.
 //
-//	 # Note: "267" here is the length of the hex-encoded data.
-//		$ hexdump -C /tmp/out
-//		00000000  0a 0a 20 20 20 20 20 32  36 37 0a 41 41 41 41 41  |..     267.AAAAA|
+//	# Note: "267" here is the length of the hex-encoded data.
+//	$ hexdump -C /tmp/out
+//	00000000  0a 0a 20 20 20 20 20 32  36 37 0a 41 41 41 41 41  |..     267.AAAAA|
 func discardWeirdHeaderGarbage(r io.Reader) error {
 	numNewLines := 0
 	b := make([]byte, 1)

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func init() {
 	flag.StringVar(&filename, "filename", "", "filename to parse (uses stdin if not set)")
 	flag.StringVar(&printContents, "print", "",
 		"if set, write each suspicious png chunk's value to stdout.\n"+
-			"May specify: 'raw', 'decompress', 'decompress-hexdecode'")
+			"May specify: '"+outputRaw+"', '"+outputDecompress+"', '"+outputDecompressHexdecode+"'")
 	flag.BoolVar(&debug, "debug", false, "enable debug logging if set. The program will emit information about\n"+
 		"unknown png chunk types")
 }

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func findProfileChunks(chunks []png.TextChunk) error {
 
 	for _, chunk := range chunks {
 		if chunk.Keyword == profileKeyword {
-			log.Printf("***POTENENTIAL INDICATOR OF COMPROMPISE*** - "+
+			log.Printf("***POTENTIAL INDICATOR OF COMPROMISE*** - "+
 				"found chunk with keyword '%s' | compressed: %t | id: %d | offset: 0x%x | len: %d",
 				profileKeyword, chunk.Compressed, numFound, chunk.Offset, len(chunk.Value))
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/jnschaeffer/cve-2022-44268-detector/internal/image/png"
 )
@@ -33,6 +32,10 @@ const (
 	//	coders/png.c:            memcmp(text[i].key, "Raw profile type ",17) == 0)
 	//	coders/png.c:      "Raw profile type ",MagickPathExtent);
 	profileKeyword = "Raw profile type"
+
+	outputRaw                 = "raw"
+	outputDecompress          = "decompress"
+	outputDecompressHexdecode = outputDecompress + "-hexdecode"
 )
 
 var (
@@ -60,8 +63,8 @@ func main() {
 	}
 
 	switch printContents {
-	case "", "raw", "decompress", "decompress-hexdecode":
-		// Permitted values.
+	case "", outputRaw, outputDecompress, outputDecompressHexdecode:
+		// Permitted output values.
 	default:
 		log.Fatalf("unknown output mode: '%s'", printContents)
 	}
@@ -119,7 +122,7 @@ func findProfileChunks(chunks []png.TextChunk) error {
 func writeChunkTo(chunk *png.TextChunk, writer io.Writer) error {
 	reader := io.NopCloser(bytes.NewReader(chunk.Value))
 
-	if strings.HasPrefix(printContents, "decompress") && chunk.Compressed {
+	if (printContents == outputDecompress || printContents == outputDecompressHexdecode) && chunk.Compressed {
 		zlibReader, err := zlib.NewReader(reader)
 		if err != nil {
 			return err
@@ -133,7 +136,7 @@ func writeChunkTo(chunk *png.TextChunk, writer io.Writer) error {
 			return fmt.Errorf("failed to discard weird header garbage - %w", err)
 		}
 
-		if printContents == "decompress-hexdecode" {
+		if printContents == outputDecompressHexdecode {
 			// For whatever reason, imagemagick hex-encodes the
 			// chunk's value... and then adds new lines after 72
 			// characters. Thus, we need to filter the newlines.


### PR DESCRIPTION
The `-print` argument now accepts the following values:

- `raw` - Write the chunk's value as-is to stdout
- `decompress` - Decompress the chunk's value prior to writing it to stdout
- `decompress-hexdecode` - Decompress and hex-decode the chunk's value prior to writing it to stdout. ImageMagick appears to first hex-encode and then compress the data using zlib compression