### PR TITLE
png: Properly handle chunk value > 768 bytes.

### DIFF
--- a/internal/image/png/reader.go
+++ b/internal/image/png/reader.go
@@ -132,6 +132,7 @@ type decoder struct {
 	interlace     int
 	textChunks    []TextChunk
 	cChunkOffset  int
+	txtBuf        *bytes.Buffer
 
 	// useTransparent and transparent are used for grayscale and truecolor
 	// transparency, as opposed to palette transparency.
@@ -902,14 +903,14 @@ func (d *decoder) parseIEND(length uint32) error {
 }
 
 func (d *decoder) parsetEXt(length uint32) error {
-	n, err := io.ReadFull(d.r, d.tmp[:length])
+	value, err := d.readChunkDynamicSize(length)
 	if err != nil {
 		return err
 	}
 
-	d.crc.Write(d.tmp[:n])
+	d.crc.Write(value)
 
-	name, data, found := bytes.Cut(d.tmp[:n], []byte{0})
+	name, data, found := bytes.Cut(value, []byte{0})
 	if !found {
 		return FormatError("malformed tEXt chunk")
 	}
@@ -925,14 +926,14 @@ func (d *decoder) parsetEXt(length uint32) error {
 }
 
 func (d *decoder) parsezTXt(length uint32) error {
-	n, err := io.ReadFull(d.r, d.tmp[:length])
+	value, err := d.readChunkDynamicSize(length)
 	if err != nil {
 		return err
 	}
 
-	d.crc.Write(d.tmp[:n])
+	d.crc.Write(value)
 
-	name, data, found := bytes.Cut(d.tmp[:n], []byte{0})
+	name, data, found := bytes.Cut(value, []byte{0})
 	if !found {
 		return FormatError("malformed zTXt chunk")
 	}
@@ -954,6 +955,25 @@ func (d *decoder) parsezTXt(length uint32) error {
 			Value:      copiedData[1:],
 		})
 	}
+}
+
+func (d *decoder) readChunkDynamicSize(length uint32) ([]byte, error) {
+	if length == 0 {
+		return nil, FormatError("tEXt/zTXt chunk length is zero")
+	}
+
+	if d.txtBuf == nil {
+		d.txtBuf = bytes.NewBuffer(nil)
+	} else {
+		d.txtBuf.Reset()
+	}
+
+	_, err := io.CopyN(d.txtBuf, d.r, int64(length))
+	if err != nil {
+		return nil, err
+	}
+
+	return d.txtBuf.Bytes(), nil
 }
 
 func (d *decoder) saveTextChunk(chunk TextChunk) error {


### PR DESCRIPTION
The decoder.tmp array field is only 768 bytes (for unknown reasons). The existing decoder code was guarding against overflowing the array. Unfortunately, when we added support for tEXt/zTXt chunks, we did not enforce such a check.

This commit adds a *bytes.Buffer that is dynamically instantiated and re-used for parsing such chunk values. Theoretically, the tmp array could be re-used for this - but it would be complicated and error-prone to do so.