### PR TITLE
pluck: Yet another detection utility

### DIFF
--- a/cmd/pluck/main.go
+++ b/cmd/pluck/main.go
@@ -1,0 +1,272 @@
+// pluck attempts to parse all the files in a directory as pngs and extracts
+// any tEXt and zTXt chunks matching a regex into an output directory.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/jnschaeffer/cve-2022-44268-detector/internal/image/png"
+	"github.com/jnschaeffer/cve-2022-44268-detector/internal/imutil"
+)
+
+var (
+	errNoIOCFound = errors.New("no potential indicators of compromise found")
+)
+
+func main() {
+	log.SetFlags(0)
+
+	err := mainWithError()
+	if err != nil {
+		log.Println("error:", err)
+
+		if errors.Is(err, errNoIOCFound) {
+			os.Exit(10)
+		}
+
+		os.Exit(1)
+	}
+}
+
+func mainWithError() error {
+	keywordRegexStr := flag.String(
+		"k",
+		"^Raw profile type$",
+		"Regex to match png chunk keyword")
+	inputDirPath := flag.String(
+		"i",
+		"",
+		"Directory containing png files to parse")
+	outputDirPath := flag.String(
+		"o",
+		"",
+		"Output directory path")
+	shouldHexdump := flag.Bool(
+		"x",
+		false,
+		"Execute 'hexdump -C' on matched png chunks and save to file")
+
+	flag.Parse()
+
+	var err error
+	flag.VisitAll(func(f *flag.Flag) {
+		if err != nil {
+			return
+		}
+
+		if f.Value.String() == "" && !strings.HasPrefix(f.Usage, "Optional") {
+			err = fmt.Errorf("please specify '-%s' - %s",
+				f.Name, f.Usage)
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	ctx, cancelFn := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancelFn()
+
+	keywordRegex, err := regexp.Compile(*keywordRegexStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse png chunk keyword regex - %w", err)
+	}
+
+	fileInfos, err := os.ReadDir(*inputDirPath)
+	if err != nil {
+		return fmt.Errorf("failed to read input dir entries - %w", err)
+	}
+
+	detectionsDirPath := filepath.Join(*outputDirPath, "detections")
+
+	detectionsDirInfo, _ := os.Stat(detectionsDirPath)
+	if detectionsDirInfo != nil {
+		if detectionsDirInfo.IsDir() {
+			return fmt.Errorf("detections dir already exists at '%s'", detectionsDirPath)
+		}
+
+		return fmt.Errorf("detections dir is a file ('%s')", detectionsDirPath)
+	}
+
+	var errs []string
+	numDetections := 0
+	numExamined := 0
+
+	for _, info := range fileInfos {
+		if info.IsDir() {
+			continue
+		}
+
+		pngFilePath := filepath.Join(*inputDirPath, info.Name())
+
+		foundAny, err := dump(ctx, &dumpConfig{
+			PNGFilePath:  pngFilePath,
+			KeywordRegex: keywordRegex,
+			OutDirPath:   detectionsDirPath,
+			ExecHexdump:  *shouldHexdump,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s - %s",
+				filepath.Base(pngFilePath), err))
+
+			continue
+		}
+
+		if foundAny {
+			numDetections++
+		}
+
+		numExamined++
+	}
+
+	log.Printf("detections: %d | examined %d | errors: %d",
+		numDetections, numExamined, len(errs))
+
+	if len(errs) > 0 {
+		errsLogPath := filepath.Join(*outputDirPath, "errors.log")
+
+		err = os.WriteFile(errsLogPath, []byte(strings.Join(errs, "\n")), 0600)
+		if err != nil {
+			return fmt.Errorf("failed to write errors log file '%s' - %s", errsLogPath, err)
+		}
+
+		return fmt.Errorf("encountered %d error(s) while dumping files - refer to '%s' for more info",
+			len(errs), errsLogPath)
+	}
+
+	if numDetections == 0 {
+		return errNoIOCFound
+	}
+
+	return nil
+}
+
+type dumpConfig struct {
+	PNGFilePath  string
+	KeywordRegex *regexp.Regexp
+	OutDirPath   string
+	ExecHexdump  bool
+}
+
+func dump(ctx context.Context, config *dumpConfig) (bool, error) {
+	pngFile, err := os.Open(config.PNGFilePath)
+	if err != nil {
+		return false, err
+	}
+	defer pngFile.Close()
+
+	chunks, err := png.FindTextChunks(pngFile)
+	_ = pngFile.Close()
+	if err != nil {
+		return false, err
+	}
+
+	basename := filepath.Base(config.PNGFilePath)
+	outDir := filepath.Join(config.OutDirPath, basename)
+	numFound := 0
+
+	for _, chunk := range chunks {
+		if !config.KeywordRegex.MatchString(chunk.Keyword) {
+			continue
+		}
+
+		if numFound == 0 {
+			err = os.MkdirAll(outDir, 0700)
+			if err != nil {
+				return false, fmt.Errorf("failed to create output dir for png file - %w", err)
+			}
+		}
+
+		outputFilePath := filepath.Join(
+			outDir,
+			fmt.Sprintf("chunk-%d-0x%x", numFound, chunk.Offset))
+
+		err = os.WriteFile(
+			outputFilePath+"-info.txt",
+			[]byte(chunkInfoString(numFound, &chunk)),
+			0600)
+		if err != nil {
+			return false, fmt.Errorf("failed to write summary file for chunk index %d - %w",
+				numFound, err)
+		}
+
+		chunkBinPath := outputFilePath + ".bin"
+
+		err = writeChunkToFile(&chunk, chunkBinPath)
+		if err != nil {
+			return false, fmt.Errorf("failed to save chunk index %d to file - %w",
+				numFound, err)
+		}
+
+		if config.ExecHexdump {
+			err = execHexdump(ctx, execHexdumpConfig{
+				OptHeader:  "",
+				InputPath:  chunkBinPath,
+				OutputPath: outputFilePath + "-hexdump.txt",
+			})
+			if err != nil {
+				return false, fmt.Errorf("failed to hexdump chunk index %d - %w",
+					numFound, err)
+			}
+		}
+
+		numFound++
+	}
+
+	return numFound > 0, nil
+}
+
+func chunkInfoString(id int, chunk *png.TextChunk) string {
+	return fmt.Sprintf("keyword='%s'\ncompressed=%t\nid=%d\noffset=0x%x\nlen=%d\n",
+		chunk.Keyword, chunk.Compressed, id, chunk.Offset, len(chunk.Value))
+}
+
+func writeChunkToFile(chunk *png.TextChunk, filePath string) error {
+	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return imutil.WriteChunkTo(chunk, f, imutil.WDecompressHexdecode)
+}
+
+type execHexdumpConfig struct {
+	OptHeader  string
+	InputPath  string
+	OutputPath string
+}
+
+func execHexdump(ctx context.Context, config execHexdumpConfig) error {
+	f, err := os.OpenFile(config.OutputPath, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if config.OptHeader != "" {
+		_, err = f.WriteString(config.OptHeader + "\n")
+		if err != nil {
+			return err
+		}
+	}
+
+	hexdump := exec.CommandContext(ctx, "hexdump", "-C", config.InputPath)
+	hexdump.Stdout = f
+
+	err = hexdump.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/imutil/doc.go
+++ b/internal/imutil/doc.go
@@ -1,0 +1,3 @@
+// Package imutil provides functionality for working with files created
+// by ImageMagick.
+package imutil

--- a/internal/imutil/pngutil.go
+++ b/internal/imutil/pngutil.go
@@ -1,0 +1,109 @@
+package imutil
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/jnschaeffer/cve-2022-44268-detector/internal/image/png"
+)
+
+// WritePNGChunkTo modes.
+const (
+	WRaw                 = "raw"
+	WDecompress          = "decompress"
+	WDecompressHexdecode = WDecompress + "-hexdecode"
+)
+
+func WriteChunkTo(chunk *png.TextChunk, writer io.Writer, mode string) error {
+	reader := io.NopCloser(bytes.NewReader(chunk.Value))
+
+	if (mode == WDecompress || mode == WDecompressHexdecode) && chunk.Compressed {
+		zlibReader, err := zlib.NewReader(reader)
+		if err != nil {
+			return err
+		}
+		defer zlibReader.Close()
+
+		reader = zlibReader
+
+		err = discardWeirdHeaderGarbage(reader)
+		if err != nil {
+			return fmt.Errorf("failed to discard weird header garbage - %w", err)
+		}
+
+		if mode == WDecompressHexdecode {
+			// For whatever reason, imagemagick hex-encodes the
+			// chunk's value... and then adds new lines after 72
+			// characters. Thus, we need to filter the newlines.
+			reader = io.NopCloser(hex.NewDecoder(&discardNewLinesReader{
+				r: reader,
+			}))
+		}
+	}
+
+	_, err := io.Copy(writer, reader)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// discardWeirdHeaderGarbage discards the weird header garbage that
+// imagetragic includes in zTXt chunks (this header appears at the
+// beginning of the decompressed data). The header's values appear
+// to be newline delimited. The last value in the header appears to
+// be the length of the hex-encoded data.
+//
+//	# Note: "267" here is the length of the hex-encoded data.
+//	$ hexdump -C /tmp/out
+//	00000000  0a 0a 20 20 20 20 20 32  36 37 0a 41 41 41 41 41  |..     267.AAAAA|
+func discardWeirdHeaderGarbage(r io.Reader) error {
+	numNewLines := 0
+	b := make([]byte, 1)
+
+	for {
+		_, err := r.Read(b)
+		if err != nil {
+			return err
+		}
+
+		if b[0] == 0x0a {
+			numNewLines++
+
+			if numNewLines == 3 {
+				return nil
+			}
+		}
+	}
+}
+
+// discardNewLinesReader discards any newline (0x0a) characters.
+// It is unbuffered... so, it sucks.
+type discardNewLinesReader struct {
+	r io.Reader
+}
+
+func (o *discardNewLinesReader) Read(p []byte) (int, error) {
+	b := make([]byte, 1)
+	numWrites := 0
+
+	for {
+		_, err := o.r.Read(b)
+		if err != nil {
+			return numWrites, err
+		}
+
+		if b[0] != 0x0a {
+			p[numWrites] = b[0]
+			numWrites++
+		}
+
+		if numWrites == len(p) {
+			return numWrites, nil
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,18 +5,15 @@
 package main
 
 import (
-	"bytes"
-	"compress/zlib"
-	"encoding/hex"
 	"errors"
 	"flag"
-	"fmt"
 	"io"
 	"log"
 	"os"
 	"regexp"
 
 	"github.com/jnschaeffer/cve-2022-44268-detector/internal/image/png"
+	"github.com/jnschaeffer/cve-2022-44268-detector/internal/imutil"
 )
 
 const (
@@ -33,10 +30,6 @@ const (
 	//	coders/png.c:            memcmp(text[i].key, "Raw profile type ",17) == 0)
 	//	coders/png.c:      "Raw profile type ",MagickPathExtent);
 	profileKeyword = "Raw profile type"
-
-	outputRaw                 = "raw"
-	outputDecompress          = "decompress"
-	outputDecompressHexdecode = outputDecompress + "-hexdecode"
 )
 
 var (
@@ -52,7 +45,7 @@ func init() {
 	flag.StringVar(&filename, "filename", "", "filename to parse (uses stdin if not set)")
 	flag.StringVar(&printContents, "print", "",
 		"if set, write each suspicious png chunk's value to stdout.\n"+
-			"May specify: '"+outputRaw+"', '"+outputDecompress+"', '"+outputDecompressHexdecode+"'")
+			"May specify: '"+imutil.WRaw+"', '"+imutil.WDecompress+"', '"+imutil.WDecompressHexdecode+"'")
 	flag.StringVar(&keywordRegexS, "keyword", "^"+profileKeyword+"$", "regex to match png chunk keyword")
 	flag.BoolVar(&debug, "debug", false, "enable debug logging if set. The program will emit information about\n"+
 		"unknown png chunk types")
@@ -68,7 +61,7 @@ func main() {
 	}
 
 	switch printContents {
-	case "", outputRaw, outputDecompress, outputDecompressHexdecode:
+	case "", imutil.WRaw, imutil.WDecompress, imutil.WDecompressHexdecode:
 		// Permitted output values.
 	default:
 		log.Fatalf("unknown output mode: '%s'", printContents)
@@ -118,7 +111,7 @@ func findChunks(keywordRegex *regexp.Regexp, chunks []png.TextChunk) error {
 				chunk.Keyword, chunk.Compressed, numFound, chunk.Offset, len(chunk.Value))
 
 			if printContents != "" {
-				err := writeChunkTo(&chunk, os.Stdout)
+				err := imutil.WriteChunkTo(&chunk, os.Stdout, printContents)
 				if err != nil {
 					return err
 				}
@@ -133,95 +126,4 @@ func findChunks(keywordRegex *regexp.Regexp, chunks []png.TextChunk) error {
 	}
 
 	return nil
-}
-
-func writeChunkTo(chunk *png.TextChunk, writer io.Writer) error {
-	reader := io.NopCloser(bytes.NewReader(chunk.Value))
-
-	if (printContents == outputDecompress || printContents == outputDecompressHexdecode) && chunk.Compressed {
-		zlibReader, err := zlib.NewReader(reader)
-		if err != nil {
-			return err
-		}
-		defer zlibReader.Close()
-
-		reader = zlibReader
-
-		err = discardWeirdHeaderGarbage(reader)
-		if err != nil {
-			return fmt.Errorf("failed to discard weird header garbage - %w", err)
-		}
-
-		if printContents == outputDecompressHexdecode {
-			// For whatever reason, imagemagick hex-encodes the
-			// chunk's value... and then adds new lines after 72
-			// characters. Thus, we need to filter the newlines.
-			reader = io.NopCloser(hex.NewDecoder(&discardNewLinesReader{
-				r: reader,
-			}))
-		}
-	}
-
-	_, err := io.Copy(writer, reader)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// discardWeirdHeaderGarbage discards the weird header garbage that
-// imagetragic includes in zTXt chunks (this header appears at the
-// beginning of the decompressed data). The header's values appear
-// to be newline delimited. The last value in the header appears to
-// be the length of the hex-encoded data.
-//
-//	# Note: "267" here is the length of the hex-encoded data.
-//	$ hexdump -C /tmp/out
-//	00000000  0a 0a 20 20 20 20 20 32  36 37 0a 41 41 41 41 41  |..     267.AAAAA|
-func discardWeirdHeaderGarbage(r io.Reader) error {
-	numNewLines := 0
-	b := make([]byte, 1)
-
-	for {
-		_, err := r.Read(b)
-		if err != nil {
-			return err
-		}
-
-		if b[0] == 0x0a {
-			numNewLines++
-
-			if numNewLines == 3 {
-				return nil
-			}
-		}
-	}
-}
-
-// discardNewLinesReader discards any newline (0x0a) characters.
-// It is unbuffered... so, it sucks.
-type discardNewLinesReader struct {
-	r io.Reader
-}
-
-func (o *discardNewLinesReader) Read(p []byte) (int, error) {
-	b := make([]byte, 1)
-	numWrites := 0
-
-	for {
-		_, err := o.r.Read(b)
-		if err != nil {
-			return numWrites, err
-		}
-
-		if b[0] != 0x0a {
-			p[numWrites] = b[0]
-			numWrites++
-		}
-
-		if numWrites == len(p) {
-			return numWrites, nil
-		}
-	}
 }


### PR DESCRIPTION
This utility examines all of the files in a directory and (assuming
they can be parsed as pngs) extracts chunks matching the keyword
regex into a sensible directory structure.
    
Optionally, it can execute 'hexdump -C' against the data extracted
from png chunks. The output of hexdump is saved to a file alongside
the chunk file(s) and info file(s).